### PR TITLE
unique key prop issue.

### DIFF
--- a/icons/GenIcon.js
+++ b/icons/GenIcon.js
@@ -4,10 +4,10 @@ import IconData from "./IconsData";
 
 const assembleChildElements = (child) => {
   if (child)
-    return child.map((grandChild) =>
+    return child.map((grandChild, idx) =>
       React.createElement(
         grandChild.tag,
-        { ...grandChild.attr },
+        { ...grandChild.attr, idx: `idx${idx}` },
         assembleChildElements(grandChild.child)
       )
     );

--- a/icons/GenIcon.js
+++ b/icons/GenIcon.js
@@ -7,7 +7,7 @@ const assembleChildElements = (child) => {
     return child.map((grandChild, idx) =>
       React.createElement(
         grandChild.tag,
-        { ...grandChild.attr, idx: `idx${idx}` },
+        { ...grandChild.attr, key: `idx${idx}` },
         assembleChildElements(grandChild.child)
       )
     );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-file-type-icons",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Renders file-type-icon",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In React v18 or higher, the following warning occurs.

Each child in an array or iterator should have a unique "key" prop.
Check the render method of 'FTIcon'. See https://reactjs.org/link/warning-keys for more informaion.
...

You can solve the problem by adding the 'key' prop as follows in the assembleChildElements function of the GenIcon.js file.

`
const assembleChildElements = (child) => {

  if (child)

    return child.map((grandChild, idx) =>

      React.createElement(

        grandChild.tag,

        { ...grandChild.attr, key: `idx${idx}` },

        assembleChildElements(grandChild.child)

      )

    );


`